### PR TITLE
add --test-mode

### DIFF
--- a/bsnes/snes/cpu/debugger/debugger.cpp
+++ b/bsnes/snes/cpu/debugger/debugger.cpp
@@ -33,8 +33,8 @@ void CPUDebugger::op_step() {
 
     if (debugger.break_on_wdm || debugger.break_on_brk) {
       if ((opcode == 0x42 && debugger.break_on_wdm) || (opcode == 0x00 && debugger.break_on_brk)) {
-        if (debugger.test_mode) {
-          uint8_t ret = CPU::mmio_read(0x420e);
+        if (debugger.test_mode && debugger.break_on_wdm) {
+          uint8_t ret = disassembler_read(opcode_pc + 1);
           std::exit(ret);
         }
         debugger.breakpoint_hit = Debugger::SoftBreakCPU;

--- a/bsnes/snes/cpu/debugger/debugger.cpp
+++ b/bsnes/snes/cpu/debugger/debugger.cpp
@@ -33,6 +33,10 @@ void CPUDebugger::op_step() {
 
     if (debugger.break_on_wdm || debugger.break_on_brk) {
       if ((opcode == 0x42 && debugger.break_on_wdm) || (opcode == 0x00 && debugger.break_on_brk)) {
+        if (debugger.test_mode) {
+          uint8_t ret = CPU::mmio_read(0x420e);
+          std::exit(ret);
+        }
         debugger.breakpoint_hit = Debugger::SoftBreakCPU;
         debugger.break_event = Debugger::BreakEvent::BreakpointHit;
         scheduler.exit(Scheduler::ExitReason::DebuggerEvent);

--- a/bsnes/snes/debugger/debugger.hpp
+++ b/bsnes/snes/debugger/debugger.hpp
@@ -48,6 +48,7 @@ public:
   bool break_on_wdm;
   bool break_on_brk;
   bool enable_debug_interface;
+  bool test_mode;
 
   void writeDebugPort(uint32 addr, uint8 data);
   uint16 debugPort;

--- a/bsnes/ui-qt/application/arguments.cpp
+++ b/bsnes/ui-qt/application/arguments.cpp
@@ -56,7 +56,6 @@ bool Application::parseArgumentSwitch(const string& arg, const string& parameter
 
   if(arg == "--test-mode") {
     breakpointEditor->setBreakOnWDM(true);
-    SNES::debugger.enable_debug_interface = true;
     SNES::debugger.test_mode = true;
     return false;
   }

--- a/bsnes/ui-qt/application/arguments.cpp
+++ b/bsnes/ui-qt/application/arguments.cpp
@@ -54,6 +54,13 @@ bool Application::parseArgumentSwitch(const string& arg, const string& parameter
     return false;
   }
 
+  if(arg == "--test-mode") {
+    breakpointEditor->setBreakOnWDM(true);
+    SNES::debugger.enable_debug_interface = true;
+    SNES::debugger.test_mode = true;
+    return false;
+  }
+
   if(arg == "--breakpoint" || arg == "-b") {
     if(parameter == "" || parameter[0] == '-') return false;
 
@@ -78,6 +85,7 @@ void Application::printArguments() {
        "  --break-on-wdm                    break on WDM opcode\n"
        "  --break-on-brk                    break on BRK opcode\n"
        "  --enable-debug-interface          enables the debug port at $420E/$420F\n"
+       "  --test-mode                       enables test mode\n"
        "  -b / --breakpoint <breakpoint>    add breakpoint\n"
        "\n"
        "Breakpoint format: <addr>[-<addr end>][=<value>][:<rwx>[:<source>]]\n"


### PR DESCRIPTION
Hi,

This adds a `--test-mode` flag. The idea here is whenever bsnes is run with this flag and you hit a `wdm` instruction, the emulator exits and returns the value at address `0x420e`. You use this as a test framework by returning `0` when tests pass and something non-zero when they fail. Using `wdm` gives us a conveniently placed breakpoint for debugging failing tests by running the same rom without the `--test-mode`  and with the `--break-on-wdm` flag. Using `0x420e` is convenient as well, because this is already wired up as a debug port. We can use it to write messages to the debugger console.

I'm still hoping to make this headless (i.e. usable without the GUI). I've never used QT before but my Googling tells me we should be able to run the bin with `-platform offscreen` flag. I spent a little time trying to get it working, but I'm no `macdeployqt` whisperer. Hoping to get this up and running so we can write some automated tests for libSFX!

To get a return code on MacOS you'll need to call the `bsnes+.app/Contents/MacOS/bsnes` binary.

Thanks, 
Kyle