### PR TITLE
Windows build

### DIFF
--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -81,7 +81,9 @@ all: build plugins
 	@echo \"all\" done
 
 deploy: all
+ifeq ($(platform),osx)
 	$(qtpath)/bin/macdeployqt $(osxbundle) $(deployqt_flags)
+endif
 	@echo \"deploy\" done
 
 include $(snes)/Makefile
@@ -146,6 +148,14 @@ ifeq ($(platform),osx)
 	cp -f ../supergameboy/libsupergameboy.dylib $(osxbundle)/Contents/Frameworks/libsupergameboy.dylib
 ifneq ($(profile),accuracy)
 	cp -f ../snesfilter/libsnesfilter.dylib $(osxbundle)/Contents/Frameworks/libsnesfilter.dylib
+endif
+else ifeq ($(platform),$(filter $(platform),win msys))
+	cp -f ../snesreader/snesreader.dll out/
+	cp -f ../snesfilter/snesfilter.dll out/
+	cp -f ../snesmusic/snesmusic.dll out/
+	cp -f ../supergameboy/supergameboy.dll out/
+ifneq ($(profile),accuracy)
+	cp -f ../snesfilter/snesfilter.dll out/
 endif
 endif
 

--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -83,6 +83,8 @@ all: build plugins
 deploy: all
 ifeq ($(platform),osx)
 	$(qtpath)/bin/macdeployqt $(osxbundle) $(deployqt_flags)
+else ifeq ($(platform),$(filter $(platform),win msys))
+	$(qtpath:=/bin/)windeployqt --no-translations --compiler-runtime out/
 endif
 	@echo \"deploy\" done
 

--- a/bsnes/ui-qt/main.cpp
+++ b/bsnes/ui-qt/main.cpp
@@ -12,7 +12,7 @@
 #elif defined(PLATFORM_WIN)
   #include "platform/platform_win.cpp"
   const char Style::Monospace[64] = "Lucida Console";
-  int Style::MonospaceSize = 12;
+  int Style::MonospaceSize = 10;
 #else
   #error "unsupported platform"
 #endif


### PR DESCRIPTION
This pull request fixes a few issues I've found when trying to build your repo on windows. (I've been building against yours rather than the official because at the moment you've merged in the improved debugger UI, while upstream has not.)

There really is not much here. The first (and most important IMHO) change is a tweak to the mono space font size on Windows. Your branch added explicit sizing, and at least on my normal DPI display Size 12 on Windows looks bad, since it seems overly large compared to all the other UI text, and stops fitting the default window sizes. Changing it to 10 seems to match the font sizes in the official Windows Builds.

I stop the makefile from calling macdeployqt on non-Mac platforms, added a call to windeployqt on Windows platforms, and added automatic copying of the built plugins on windows over to the main output directory. 